### PR TITLE
Add client API docs

### DIFF
--- a/docs/Client/NinjaTrader.Cbi.TraceLevels.md
+++ b/docs/Client/NinjaTrader.Cbi.TraceLevels.md
@@ -1,0 +1,25 @@
+# NinjaTrader.Cbi.TraceLevels
+
+`TraceLevels` is an enumeration that defines various tracing flags used throughout the NinjaTrader platform for debugging and logging. Multiple flags can be combined since the enum is decorated with `[Flags]`.
+
+## Values
+- `All` (268435455) – Enables all tracing categories.
+- `None` (0) – Disables tracing.
+- `Bars` (1) – Trace operations related to bar series updates.
+- `Connect` (4) – Trace connection events.
+- `Database` (8) – Trace database interactions.
+- `Gui` (16) – Trace UI related activity.
+- `Indicator` (32) – Trace indicator processing.
+- `ResolveInstrument` (64) – Trace instrument lookup.
+- `MarketData` (128) – Trace incoming market data.
+- `MarketDepth` (256) – Trace level‑II market depth.
+- `Native` (512) – Trace native wrapper calls.
+- `News` (1024) – Trace news data.
+- `Order` (2048) – Trace order submission and updates.
+- `Strategy` (4096) – Trace strategy execution.
+- `Strict` (8192) – Enable strict validation tracing.
+- `Test` (16384) – Trace test framework events.
+- `Timer` (32768) – Trace timer callbacks.
+- `Server` (65536) – Trace server communication.
+- `Alerts` (131072) – Trace alert generation.
+- `FundamentalData` (262144) – Trace fundamental data events.

--- a/docs/Client/NinjaTrader.Client.Client.md
+++ b/docs/Client/NinjaTrader.Client.Client.md
@@ -1,0 +1,42 @@
+# NinjaTrader.Client.Client
+
+`Client` is the main programmatic entry for communicating with the NinjaTrader desktop application. It implements `IClient` and exposes methods for market data access, order submission and account queries.
+
+Most methods return an `int` result code or a value depending on the query. A minimal outline of available calls is listed below.
+
+## Key Methods
+- `Ask(instrument, price, size)` – Submit an ask quote.
+- `AskPlayback(instrument, price, size, timestamp)` – Feed historical ask data for playback.
+- `AvgEntryPrice(instrument, account)` – Get the average entry price for an instrument and account.
+- `AvgFillPrice(orderId)` – Obtain the average fill price for an order.
+- `Bid(instrument, price, size)` – Submit a bid quote.
+- `BidPlayback(instrument, price, size, timestamp)` – Feed historical bid data for playback.
+- `BuyingPower(account)` – Query available buying power.
+- `CashValue(account)` – Retrieve current cash value.
+- `Command(command, account, instrument, action, quantity, orderType, limitPrice, stopPrice, timeInForce, oco, orderId, tpl, strategy)` – Generic command interface for order operations.
+- `ConfirmOrders(confirm)` – Enable or disable order confirmations.
+- `Connected(showMessage)` – Returns connection status.
+- `Dispose()` – Clean up resources.
+- `Filled(orderId)` – Check if an order is filled.
+- `GetDouble(key)` – Retrieve a double value for a configuration key.
+- `GetInt(key)` – Retrieve an integer value for a configuration key.
+- `GetString(key)` – Retrieve a string value for a configuration key.
+- `Last(instrument, price, size)` – Submit a last trade quote.
+- `LastPlayback(instrument, price, size, timestamp)` – Feed historical last trade data for playback.
+- `MarketData(instrument, type)` – Query market data of a specific `MarketDataType`.
+- `MarketPosition(instrument, account)` – Get the net position for an account.
+- `NewOrderId()` – Generate a new order identifier.
+- `Orders(account)` – List working orders for an account.
+- `OrderStatus(orderId)` – Retrieve the status string for an order.
+- `QueryInstrument()` – Return serialized information about instruments.
+- `RealizedPnL(account)` – Get realized profit and loss for an account.
+- `SetAllocReturnString(value)` – Configure allocation string handling.
+- `SetMaxReturnStringLength(value)` – Configure maximum length of returned strings.
+- `SetUp(host, port)` – Establish a connection to the desktop application.
+- `StopOrders(strategyId)` – List stop orders for a strategy.
+- `Strategies(account)` – List running strategies for an account.
+- `StrategyPosition(strategyId)` – Get a strategy's current position.
+- `SubscribeMarketData(instrument)` – Begin streaming real-time market data.
+- `TargetOrders(strategyId)` – List target orders for a strategy.
+- `TearDown()` – Disconnect from the application.
+- `UnsubscribeMarketData(instrument)` – Stop streaming market data.

--- a/docs/Client/NinjaTrader.Client.IClient.md
+++ b/docs/Client/NinjaTrader.Client.IClient.md
@@ -1,0 +1,5 @@
+# NinjaTrader.Client.IClient
+
+`IClient` defines the contract implemented by `Client` for interacting with the NinjaTrader desktop application. Methods mirror those exposed by the client API.
+
+Refer to [`NinjaTrader.Client.Client`](NinjaTrader.Client.Client.md) for a description of each method.

--- a/docs/Client/NinjaTrader.Core.Globals.md
+++ b/docs/Client/NinjaTrader.Core.Globals.md
@@ -1,0 +1,8 @@
+# NinjaTrader.Core.Globals
+
+`Globals` exposes common configuration values for the NinjaTrader client.
+
+## Properties
+- `ProductName` – Name of the running NinjaTrader product.
+- `DataFolderName` – Name of the folder holding platform data.
+- `UserDataDir` – Path to the user's data directory.

--- a/docs/Client/NinjaTrader.Data.MarketDataType.md
+++ b/docs/Client/NinjaTrader.Data.MarketDataType.md
@@ -1,0 +1,16 @@
+# NinjaTrader.Data.MarketDataType
+
+`MarketDataType` enumerates the different categories of market data that can be requested from the client API.
+
+## Values
+- `Ask` – Current ask price.
+- `Bid` – Current bid price.
+- `Last` – Last traded price.
+- `DailyHigh` – Session high price.
+- `DailyLow` – Session low price.
+- `DailyVolume` – Session volume.
+- `LastClose` – Prior session close price.
+- `Opening` – Opening price.
+- `OpenInterest` – Open interest figure.
+- `Settlement` – Settlement price.
+- `Unknown` – Data type not specified.


### PR DESCRIPTION
## Summary
- create docs/Client directory
- document TraceLevels enum
- document Globals class
- document Client API class
- document MarketDataType enum
- document IClient interface

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845b6833fa883339a94a82070230279